### PR TITLE
Add React 16 as possible peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "eslint-plugin-react": "3.x.x"
   },
   "peerDependencies": {
-    "react": "0.14.x || 15.x.x",
-    "react-dom": "0.14.x || 15.x.x"
+    "react": "0.14.x || 15.x.x || 16.x.x",
+    "react-dom": "0.14.x || 15.x.x || 16.x.x"
   },
   "dependencies": {
     "babel-runtime": "6.x.x",


### PR DESCRIPTION
Fixes `react-mounter@1.2.0 requires a peer of react@0.14.x || 15.x.x but none is installed. You must install peer dependencies yourself.` warning when installing react-mounter on React 16 projects.